### PR TITLE
feat: routing - tunnel apps - mode: direct (lockdown)

### DIFF
--- a/app/assets/l10n/ru/ui.json
+++ b/app/assets/l10n/ru/ui.json
@@ -719,6 +719,9 @@
   "All": {
     "value": "Все"
   },
+  "All apps enter the tunnel and follow your routing rules (default).": {
+    "value": "Все приложения попадают в туннель и следуют вашим правилам маршрутизации (по умолчанию)."
+  },
   "All directions": {
     "value": "Все Направления"
   },
@@ -748,6 +751,9 @@
   },
   "Allow-list": {
     "value": "Белый список"
+  },
+  "Allow-list and Deny-list exclude apps from the tunnel. Android lockdown blocks excluded apps. Direct (lockdown) keeps all apps in the tunnel and connects listed apps directly through LxBox.": {
+    "value": "Списки разрешённых и исключённых оставляют часть приложений вне туннеля. Android lockdown блокирует такие приложения. Режим «Напрямую (lockdown)» сохраняет все приложения в туннеле и подключает приложения из списка напрямую через LxBox."
   },
   "Allowed — foreground service shows VPN status": {
     "value": "Разрешены — foreground-сервис показывает статус VPN"
@@ -1029,6 +1035,9 @@
   },
   "Choose a file first": {
     "value": "Сначала выберите файл"
+  },
+  "Choose how the listed apps use the VPN.\n\n• Off — all apps use the tunnel and your routing rules.\n• Allow-list — only listed apps enter the tunnel.\n• Deny-list — listed apps bypass the tunnel.\n• Direct (lockdown) — all apps enter the tunnel; listed apps connect directly through LxBox before other routing rules. DNS follows your DNS settings.\n\nAndroid blocks apps outside the tunnel when \"Block connections without VPN\" is enabled. Use Direct (lockdown) to keep selected apps connected while the VPN is running. These apps still see an active VPN; when it stops, Android blocks their connections too.\n\nThis applies to the Android profile running LxBox. Restart the VPN after switching modes.": {
+    "value": "Выберите, как приложения из списка используют VPN.\n\n• Выкл. — все приложения используют туннель и ваши правила маршрутизации.\n• Список разрешённых — только приложения из списка попадают в туннель.\n• Список исключённых — приложения из списка обходят туннель.\n• Напрямую (lockdown) — все приложения попадают в туннель; приложения из списка подключаются напрямую через LxBox до остальных правил маршрутизации. DNS работает по вашим настройкам DNS.\n\nAndroid блокирует приложения вне туннеля при включённой настройке «Блокировать соединения без VPN». Используйте режим «Напрямую (lockdown)», чтобы выбранные приложения сохраняли доступ к сети при работающем VPN. Эти приложения по-прежнему видят активный VPN; при его остановке Android также блокирует их соединения.\n\nРежим действует в профиле Android, в котором запущен LxBox. После смены режима перезапустите VPN."
   },
   "Choose…": {
     "value": "Выбрать…"
@@ -1540,6 +1549,9 @@
   },
   "Diagnostics settings": {
     "value": "Настройки диагностики"
+  },
+  "Direct (lockdown)": {
+    "value": "Напрямую (lockdown)"
   },
   "Direct (no VPN)": {
     "value": "Напрямую (без VPN)"
@@ -2922,6 +2934,9 @@
   "Online URL": {
     "value": "Онлайн-URL"
   },
+  "Only selected apps enter the tunnel. Android lockdown blocks all other apps.": {
+    "value": "Только выбранные приложения попадают в туннель. Android lockdown блокирует все остальные приложения."
+  },
   "Only single servers can be moved": {
     "value": "Переносить можно только одиночные серверы"
   },
@@ -3691,6 +3706,12 @@
   "Select server": {
     "value": "Показать выбранный сервер"
   },
+  "Selected apps bypass the tunnel. Android lockdown blocks these apps; use Direct (lockdown) to keep them connected.": {
+    "value": "Выбранные приложения обходят туннель. Android lockdown блокирует их; для доступа к сети используйте режим «Напрямую (lockdown)»."
+  },
+  "Selected apps connect directly through LxBox, even with Android lockdown enabled. Other apps follow routing rules. DNS follows your DNS settings. Requires a running VPN.": {
+    "value": "Выбранные приложения подключаются напрямую через LxBox, даже при включённом Android lockdown. Остальные приложения следуют правилам маршрутизации. DNS работает по вашим настройкам DNS. Требуется работающий VPN."
+  },
   "Selection mode": "Режим выбора",
   "Selector \"%1$s\" default \"%2$s\" is not in the options list.": {
     "value": "У селектора «%1$s» значение по умолчанию «%2$s» отсутствует в списке вариантов."
@@ -4181,9 +4202,6 @@
   "This frees %s. Memory profiles cannot be recovered afterwards.": {
     "value": "Освободится %s. Восстановить профили памяти после удаления нельзя."
   },
-  "This is OS-level split-tunneling. It controls which apps see the VPN tunnel at all — packets from excluded apps go directly via cellular/wifi without entering sing-box.\n\n• Off — every app uses the VPN (default)\n• Allow-list — ONLY listed apps go through VPN; everything else bypasses\n• Deny-list — listed apps bypass VPN; everything else goes through\n\nNote: apps in the Allow-list still go through your normal routing rules. Apps that bypass the tunnel are not visible to sing-box at all — your custom rules with package_name will not match them.\n\nChanges require a full VPN restart to apply (Android creates the tun interface only at start).": {
-    "value": "Это разделение туннеля на уровне ОС: оно определяет, какие приложения вообще видят VPN-туннель — пакеты исключённых приложений идут напрямую через мобильную сеть или Wi-Fi, минуя sing-box.\n\n• Выключено — все приложения используют VPN (по умолчанию)\n• Белый список — через VPN идут ТОЛЬКО перечисленные приложения, остальные в обход\n• Чёрный список — перечисленные приложения идут в обход VPN, остальные через туннель\n\nВажно: приложения из белого списка по-прежнему проходят через обычные правила маршрутизации. Приложения в обход туннеля для sing-box невидимы — правила с package_name их не поймают.\n\nИзменения требуют полного перезапуска VPN (Android создаёт tun-интерфейс только при старте)."
-  },
   "This is an auto-select node — it has no connection of its own. Open a member to diagnose it.": {
     "value": "Это узел автовыбора — своего соединения у него нет. Откройте участника, чтобы проверить его."
   },
@@ -4271,8 +4289,8 @@
   "Tunnel apps": {
     "value": "Приложения туннеля"
   },
-  "Tunnel apps — OS-level split": {
-    "value": "Приложения туннеля — разделение на уровне ОС"
+  "Tunnel apps — routing modes": {
+    "value": "Приложения туннеля — режимы маршрутизации"
   },
   "Tunnel is always active. Best reliability — pushes and long-lived sockets survive. Higher battery use.": {
     "value": "Туннель активен всегда. Максимальная надёжность — push-уведомления и долгоживущие соединения сохраняются. Расход батареи выше."

--- a/app/lib/screens/tun_apps_tab.dart
+++ b/app/lib/screens/tun_apps_tab.dart
@@ -1,8 +1,10 @@
-// §046 — Tunnel apps tab. OS-level split-tunneling control.
+// §046 — Tunnel apps: OS-level split and direct routing inside the VPN.
 //
 // UI для `tun_apps` storage shape (mode + packages list).
-// Builder applyTunPackages() трансформирует это в config.tun.{include,exclude}_package.
-// Native слой BoxVpnService.kt:557-560 далее пробрасывает в VpnService.Builder.
+// Builder applyTunPackages(): allow/deny → tun.{include,exclude}_package;
+// direct → правило package_name внутри tun (совместимо с Android lockdown).
+// Native слой BoxVpnService.openTun пробрасывает include/exclude в
+// VpnService.Builder.addAllowedApplication/addDisallowedApplication.
 //
 // Изменения требуют **full VPN restart** (не light reload) — addAllowedApplication
 // applies только на builder.establish(). Banner показывается при tunnel up.
@@ -151,9 +153,9 @@ class _TunAppsTabState extends State<TunAppsTab>
     showDialog<void>(
       context: context,
       builder: (ctx) => AlertDialog(
-        title: Text(getLocalText.s("Tunnel apps — OS-level split")),
+        title: Text(getLocalText.s("Tunnel apps — routing modes")),
         content: SingleChildScrollView(
-          child: Text(getLocalText.s("This is OS-level split-tunneling. It controls which apps see the VPN tunnel at all — packets from excluded apps go directly via cellular/wifi without entering sing-box.\n\n• Off — every app uses the VPN (default)\n• Allow-list — ONLY listed apps go through VPN; everything else bypasses\n• Deny-list — listed apps bypass VPN; everything else goes through\n\nNote: apps in the Allow-list still go through your normal routing rules. Apps that bypass the tunnel are not visible to sing-box at all — your custom rules with package_name will not match them.\n\nChanges require a full VPN restart to apply (Android creates the tun interface only at start).")),
+          child: Text(getLocalText.s("Choose how the listed apps use the VPN.\n\n• Off — all apps use the tunnel and your routing rules.\n• Allow-list — only listed apps enter the tunnel.\n• Deny-list — listed apps bypass the tunnel.\n• Direct (lockdown) — all apps enter the tunnel; listed apps connect directly through LxBox before other routing rules. DNS follows your DNS settings.\n\nAndroid blocks apps outside the tunnel when \"Block connections without VPN\" is enabled. Use Direct (lockdown) to keep selected apps connected while the VPN is running. These apps still see an active VPN; when it stops, Android blocks their connections too.\n\nThis applies to the Android profile running LxBox. Restart the VPN after switching modes.")),
         ),
         actions: [
           TextButton(
@@ -193,11 +195,7 @@ class _TunAppsTabState extends State<TunAppsTab>
             Text(getLocalText.s("Mode"), style: tt.titleMedium),
             const SizedBox(width: 4),
             Tooltip(
-              message:
-                  'OS-level split-tunneling. Apps in Allow-list go through tun '
-                  '— routing rules apply normally. Apps outside Allow-list (or '
-                  'in Deny-list) bypass VPN entirely; sing-box doesn\'t see '
-                  'them, custom rules with package_name won\'t match.',
+              message: getLocalText.s("Allow-list and Deny-list exclude apps from the tunnel. Android lockdown blocks excluded apps. Direct (lockdown) keeps all apps in the tunnel and connects listed apps directly through LxBox."),
               triggerMode: TooltipTriggerMode.tap,
               child: Icon(
                 Icons.info_outline,
@@ -242,16 +240,22 @@ class _TunAppsTabState extends State<TunAppsTab>
           ],
         ),
         const SizedBox(height: 8),
-        SegmentedButton<String>(
-          segments: [
-            ButtonSegment(value: 'off', label: Text(getLocalText.s("Off"))),
-            ButtonSegment(
-                value: 'allow', label: Text(getLocalText.s("Allow-list"))),
-            ButtonSegment(
-                value: 'deny', label: Text(getLocalText.s("Deny-list"))),
+        DropdownButtonFormField<String>(
+          initialValue: _cfg.mode,
+          isExpanded: true,
+          decoration: const InputDecoration(border: OutlineInputBorder()),
+          items: [
+            DropdownMenuItem(value: 'off', child: Text(getLocalText.s("Off"))),
+            DropdownMenuItem(
+                value: 'allow', child: Text(getLocalText.s("Allow-list"))),
+            DropdownMenuItem(
+                value: 'deny', child: Text(getLocalText.s("Deny-list"))),
+            DropdownMenuItem(
+                value: 'direct', child: Text(getLocalText.s("Direct (lockdown)"))),
           ],
-          selected: {_cfg.mode},
-          onSelectionChanged: (s) => _setMode(s.first),
+          onChanged: (mode) {
+            if (mode != null) _setMode(mode);
+          },
         ),
         const SizedBox(height: 8),
         Text(
@@ -359,11 +363,13 @@ class _TunAppsTabState extends State<TunAppsTab>
   String _modeDescription(String mode) {
     switch (mode) {
       case 'allow':
-        return 'Only selected apps go through VPN. Others bypass via cellular/wifi.';
+        return getLocalText.s("Only selected apps enter the tunnel. Android lockdown blocks all other apps.");
       case 'deny':
-        return 'Selected apps bypass VPN. Others go through.';
+        return getLocalText.s("Selected apps bypass the tunnel. Android lockdown blocks these apps; use Direct (lockdown) to keep them connected.");
+      case 'direct':
+        return getLocalText.s("Selected apps connect directly through LxBox, even with Android lockdown enabled. Other apps follow routing rules. DNS follows your DNS settings. Requires a running VPN.");
       default:
-        return 'All apps go through VPN (default).';
+        return getLocalText.s("All apps enter the tunnel and follow your routing rules (default).");
     }
   }
 }

--- a/app/lib/services/builder/build_config.dart
+++ b/app/lib/services/builder/build_config.dart
@@ -75,8 +75,9 @@ class BuildSettings {
   /// `core_chain_capability.dart`).
   final String coreVersion;
 
-  /// §046: OS-level split-tunneling apps list. `null` = pipeline возьмёт
-  /// дефолт (mode=off — все apps через tun, sing-box обычное поведение).
+  /// §046: список приложений для OS-level split-tunneling или прямого выхода
+  /// внутри VPN (direct). `null` = pipeline возьмёт дефолт
+  /// (mode=off — все apps через tun, sing-box обычное поведение).
   final TunAppsConfig? tunApps;
 
   /// §119: VPN-mode (proxy/vpn/vpn_proxy). `null` = mode=vpn (текущее
@@ -528,8 +529,10 @@ Future<BuildResult> buildConfig({
   // applyVpnMode удалён. К этому моменту inbounds[] уже финальный: в proxy
   // tun-in физически отсутствует → applyTunPackages (по type=='tun') no-op'ит.
 
-  // §046: OS-level split-tunneling. Должен быть **последним** post-step'ом —
-  // финальный transform tun-inbound, после всего остального.
+  // §046: Tunnel apps. Должен быть **последним** post-step'ом сборки
+  // inbounds, route.rules и DNS — финальный transform tun-inbound.
+  // allow/deny меняют только tun; direct сохраняет начальную обработку DNS
+  // и добавляет package_name → direct-out перед пользовательскими маршрутами.
   if (settings.tunApps != null) {
     applyTunPackages(config, settings.tunApps!);
   }

--- a/app/lib/services/builder/post_steps/tun_packages.dart
+++ b/app/lib/services/builder/post_steps/tun_packages.dart
@@ -1,22 +1,33 @@
 part of '../post_steps.dart';
 
-/// Post-step: §046 — OS-level split-tunneling. Подставляет `include_package`
-/// или `exclude_package` в `inbound[type=tun]` на основе `tun_apps` storage.
+/// Post-step: §046 — настройки Tunnel apps из `tun_apps` storage.
+/// Подставляет `include_package` / `exclude_package` в первый `inbound[type=tun]`
+/// либо оставляет приложения внутри VPN и добавляет прямой маршрут.
 ///
 /// Mode → sing-box config:
-/// - `off`        → ничего не пишем (sing-box default = все apps через tun)
-/// - `allow`      → `tun.include_package = packages` (только эти через tun)
-/// - `deny`       → `tun.exclude_package = packages` (все КРОМЕ этих)
+/// - `off`    → ничего не пишем (sing-box default = все apps через tun)
+/// - `allow`  → `tun.include_package = packages` (только эти через tun)
+/// - `deny`   → `tun.exclude_package = packages` (все КРОМЕ этих)
+/// - `direct` → удаляем include/exclude; все apps остаются в tun, выбранные
+///   пакеты идут через `package_name` → `direct-out`. Android lockdown
+///   сохраняется; DNS следует существующим настройкам, включая FakeIP.
 ///
-/// libbox потом читает эти поля из config и передаёт в native слой
-/// (`BoxVpnService.openTun` → `addAllowedApplication`/`addDisallowedApplication`,
-/// ~`BoxVpnService.kt:208-211`). Применяется на `builder.establish()` — нужен
-/// FULL VPN restart, light reload не работает.
+/// libbox читает include/exclude из config и передаёт в native слой
+/// (`BoxVpnService.openTun` → `addAllowedApplication`/`addDisallowedApplication`).
+/// Применяется на `builder.establish()` — нужен FULL VPN restart,
+/// light reload не работает.
 ///
-/// Если `mode != off` но `packages` пустой — silently no-op (нечего apply'ить).
-/// Если в config нет tun-inbound — silently no-op (некуда apply'ить).
+/// Если `packages` пустой, allow/deny — silently no-op; direct удаляет
+/// OS-фильтры, но не добавляет маршруты (иначе все apps ушли бы напрямую).
+/// Если в config нет tun-inbound (Proxy mode) — silently no-op.
+///
+/// Важно: если Android не определил владельца соединения (например, при
+/// `curl --interface tun1`), package_name не совпадёт и сработают обычные
+/// правила. Для блокировки такого трафика нужен отдельный Unknown traffic
+/// с Reject перед маршрутами через прокси; этот режим его не включает.
 void applyTunPackages(Map<String, dynamic> config, TunAppsConfig tunApps) {
-  if (tunApps.isOff || tunApps.packages.isEmpty) return;
+  if (tunApps.isOff || !TunAppsConfig.isValidMode(tunApps.mode)) return;
+  if (tunApps.packages.isEmpty && !tunApps.isDirect) return;
 
   final inbounds = config['inbounds'];
   if (inbounds is! List) return;
@@ -29,6 +40,55 @@ void applyTunPackages(Map<String, dynamic> config, TunAppsConfig tunApps) {
     }
   }
   if (tun == null) return;
+
+  if (tunApps.isDirect) {
+    // Оставляем приложения внутри VpnService: lockdown блокирует исключённые.
+    // Удаляем OS-фильтры, в том числе заданные пользовательским шаблоном.
+    tun.remove('include_package');
+    tun.remove('exclude_package');
+    if (tunApps.packages.isEmpty) return;
+
+    // Ограничиваем правило этим tun, чтобы в VPN+Proxy не затронуть mixed-in.
+    // Встроенный шаблон уже задаёт tag; для пользовательского tun без тега
+    // назначаем свободный, без конфликта с остальными inbounds.
+    if (tun['tag'] is! String || (tun['tag'] as String).isEmpty) {
+      final usedTags = inbounds.whereType<Map>().map((i) => i['tag']).toSet();
+      var tag = 'tun-apps-in';
+      while (usedTags.contains(tag)) {
+        tag = '$tag-1';
+      }
+      tun['tag'] = tag;
+    }
+
+    final route =
+        config.putIfAbsent('route', () => <String, dynamic>{})
+            as Map<String, dynamic>;
+    // Включаем поиск UID/пакета и native autoDetectInterfaceControl → protect.
+    route['find_process'] = true;
+    route['auto_detect_interface'] = true;
+    final rules = List<dynamic>.from(route['rules'] as List? ?? const []);
+    // Сохраняем начальную обработку пакетов, особенно hijack-dns: прямой выход
+    // на виртуальный DNS-адрес tun закончился бы таймаутом. DNS, включая
+    // FakeIP, продолжает использовать существующую конфигурацию DNS.
+    final index = rules.indexWhere(
+      (r) =>
+          r is! Map ||
+          !const {
+            'sniff',
+            'hijack-dns',
+            'resolve',
+            'route-options',
+          }.contains(r['action']),
+    );
+    rules.insert(index < 0 ? rules.length : index, <String, dynamic>{
+      'inbound': [tun['tag']],
+      'package_name': List<String>.from(tunApps.packages),
+      'action': 'route',
+      'outbound': kDirectOutboundTag,
+    });
+    route['rules'] = rules;
+    return;
+  }
 
   final field = tunApps.isAllow ? 'include_package' : 'exclude_package';
   tun[field] = List<String>.from(tunApps.packages);

--- a/app/lib/services/debug/handlers/help.dart
+++ b/app/lib/services/debug/handlers/help.dart
@@ -448,7 +448,7 @@ GET|PUT /settings/enabled_groups               body {"groups":["tag",...]} (conf
 GET|PUT /settings/vpn_mode                     body partial {mode,proxy_protocol,proxy_port,proxy_listen,proxy_auth,proxy_user,proxy_pass} (?rebuild)
 GET|PUT /settings/ping_options                 URLTest defaults. body partial {url?,timeout_ms?,groups?} (groups = per-group overrides map)
 GET|PUT|DELETE /settings/ping_options/groups/{tag}  Per-group URLTest override. PUT body {url?,timeout_ms?} (≥1 required); DELETE clears
-GET|PUT /settings/tun_apps                     Per-app tunnel list. body {"mode":"off|allow|deny","packages":["pkg",...]} (config-significant, ?rebuild)
+GET|PUT /settings/tun_apps                     Per-app tunnel list. body {"mode":"off|allow|deny|direct","packages":["pkg",...]} (config-significant, ?rebuild)
 PUT    /settings/vars/{key}                    body {"value":"..."}; blocklist: debug_token/debug_enabled/debug_port
 DELETE /settings/vars/{key}                    Delete var
 PUT    /settings/dns_options/servers           body {"servers":[...]}
@@ -682,7 +682,7 @@ const Map<String, dynamic> _capabilityJson = {
     {'method': 'GET|PUT', 'path': '/settings/vpn_mode', 'body': 'partial {mode,proxy_protocol,proxy_port,proxy_listen,proxy_auth,proxy_user,proxy_pass}', 'description': 'VPN/proxy mode (config-significant, ?rebuild)'},
     {'method': 'GET|PUT', 'path': '/settings/ping_options', 'body': 'partial {url?,timeout_ms?,groups?}', 'description': 'URLTest defaults (groups = per-group overrides map)'},
     {'method': 'GET|PUT|DELETE', 'path': '/settings/ping_options/groups/{tag}', 'body': '{url?,timeout_ms?} (PUT, ≥1 required)', 'description': 'Per-group URLTest override; DELETE clears it'},
-    {'method': 'GET|PUT', 'path': '/settings/tun_apps', 'body': '{"mode":"off|allow|deny","packages":["pkg",...]}', 'description': 'Per-app tunnel list (config-significant, ?rebuild)'},
+    {'method': 'GET|PUT', 'path': '/settings/tun_apps', 'body': '{"mode":"off|allow|deny|direct","packages":["pkg",...]}', 'description': 'Per-app tunnel list (config-significant, ?rebuild)'},
     {'method': 'PUT', 'path': '/settings/vars/{key}', 'body': '{"value":"..."}', 'description': 'Set var (blocklist: debug_token/debug_enabled/debug_port)'},
     {'method': 'DELETE', 'path': '/settings/vars/{key}', 'description': 'Delete var'},
     {'method': 'PUT', 'path': '/settings/dns_options/servers', 'body': '{"servers":[...]}', 'description': 'Set DNS servers list'},

--- a/app/lib/services/debug/handlers/settings.dart
+++ b/app/lib/services/debug/handlers/settings.dart
@@ -669,7 +669,7 @@ Future<DebugResponse> _getTunApps() async {
 }
 
 /// `PUT /settings/tun_apps` — overwrite shape целиком.
-/// Body: `{"mode":"off|allow|deny", "packages":["pkg1","pkg2",...]}`.
+/// Body: `{"mode":"off|allow|deny|direct", "packages":["pkg1","pkg2",...]}`.
 /// Дубликаты в `packages` schлопываются (idempotent). Невалидные fields → 400.
 ///
 /// Изменения требуют **full VPN restart** для apply (Android tun creates только
@@ -681,7 +681,7 @@ Future<DebugResponse> _putTunApps(DebugRequest req, DebugContext ctx) async {
   final mode = body['mode'];
   // §293 — валидатор на модели (единый источник с storage-сеттером).
   if (mode is! String || !TunAppsConfig.isValidMode(mode)) {
-    throw const BadRequest('field "mode" must be one of: off|allow|deny');
+    throw const BadRequest('field "mode" must be one of: off|allow|deny|direct');
   }
 
   final pkgsRaw = body['packages'];

--- a/app/lib/services/settings_storage.dart
+++ b/app/lib/services/settings_storage.dart
@@ -897,22 +897,22 @@ class SettingsStorage {
       _replaceRaw(snapshot, merge: merge);
 
   // ---------------------------------------------------------------------------
-  // Tunnel apps — OS-level split-tunneling (§046)
+  // Tunnel apps — OS-level split-tunneling and direct routing inside VPN (§046)
   //
-  // Storage shape: `{mode: "off"|"allow"|"deny", packages: [pkg, ...]}`.
+  // Storage shape: `{mode: "off"|"allow"|"deny"|"direct", packages: [pkg, ...]}`.
   // Builder transforms into `inbound[tun].include_package` (mode=allow) или
   // `exclude_package` (mode=deny); mode=off → ничего не пишем (sing-box default
   // = всё через tun).
+  // mode=direct → все apps остаются внутри tun, package_name → direct-out
+  // после обработки DNS и перед пользовательскими маршрутами (lockdown).
   //
-  // Native слой (BoxVpnService.kt:557-560) уже умеет — просто читает
+  // Native слой (BoxVpnService.openTun) уже умеет — просто читает
   // `options.includePackage`/`excludePackage` от libbox и зовёт
   // `VpnService.Builder.addAllowedApplication`/`addDisallowedApplication`.
   // applies на `builder.establish()` — на изменение нужен FULL VPN restart.
   // ---------------------------------------------------------------------------
 
   static const _tunAppsModeOff = 'off';
-  static const _tunAppsModeAllow = 'allow';
-  static const _tunAppsModeDeny = 'deny';
 
   /// Возвращает текущий tun-apps config. Default: `{mode: 'off', packages: []}`
   /// — backward-compat для existing юзеров.

--- a/app/lib/services/settings_storage/backup_tun.dart
+++ b/app/lib/services/settings_storage/backup_tun.dart
@@ -115,10 +115,8 @@ Future<TunAppsConfig> _getTunApps() async {
             ?.whereType<String>()
             .toList() ??
         const <String>[];
-    if (mode == SettingsStorage._tunAppsModeAllow ||
-        mode == SettingsStorage._tunAppsModeDeny ||
-        mode == SettingsStorage._tunAppsModeOff) {
-      return TunAppsConfig(mode: mode as String, packages: packages);
+    if (mode is String && TunAppsConfig.isValidMode(mode)) {
+      return TunAppsConfig(mode: mode, packages: packages);
     }
   }
   return const TunAppsConfig(
@@ -129,7 +127,7 @@ Future<TunAppsConfig> _getTunApps() async {
 
 Future<void> _setTunApps(TunAppsConfig cfg, {bool flush = true}) async {
   if (!TunAppsConfig.isValidMode(cfg.mode)) {
-    throw ArgumentError('tun_apps.mode must be off|allow|deny: ${cfg.mode}');
+    throw ArgumentError('tun_apps.mode must be off|allow|deny|direct: ${cfg.mode}');
   }
   final dedup = <String>{};
   for (final p in cfg.packages) {
@@ -151,18 +149,19 @@ Future<void> _setTunApps(TunAppsConfig cfg, {bool flush = true}) async {
 class TunAppsConfig {
   const TunAppsConfig({required this.mode, required this.packages});
 
-  /// `"off"` | `"allow"` | `"deny"`.
+  /// `"off"` | `"allow"` | `"deny"` | `"direct"` (direct routing inside the VPN).
   final String mode;
   final List<String> packages;
 
   /// §293 — валиден ли `mode` (единый источник для write-путей: storage-сеттер
   /// и Debug-handler; был инлайн-список в обоих).
   static bool isValidMode(String mode) =>
-      mode == 'off' || mode == 'allow' || mode == 'deny';
+      mode == 'off' || mode == 'allow' || mode == 'deny' || mode == 'direct';
 
   bool get isOff => mode == 'off';
   bool get isAllow => mode == 'allow';
   bool get isDeny => mode == 'deny';
+  bool get isDirect => mode == 'direct';
 
   TunAppsConfig copyWith({String? mode, List<String>? packages}) =>
       TunAppsConfig(

--- a/app/test/builder/tun_direct_build_test.dart
+++ b/app/test/builder/tun_direct_build_test.dart
@@ -1,0 +1,113 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lxbox/models/custom_rule.dart';
+import 'package:lxbox/models/parser_config.dart';
+import 'package:lxbox/services/builder/build_config.dart';
+import 'package:lxbox/services/settings_storage.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const paths = MethodChannel('plugins.flutter.io/path_provider');
+  late Directory tmp;
+
+  setUp(() async {
+    tmp = await Directory.systemTemp.createTemp('lxbox_tun_direct_');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(paths, (_) async => tmp.path);
+    SettingsStorage.resetCacheForTesting();
+  });
+
+  tearDown(() async {
+    SettingsStorage.resetCacheForTesting();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(paths, null);
+    await tmp.delete(recursive: true);
+  });
+
+  Future<BuildResult> build(String appsMode, String vpnMode) => buildConfig(
+    lists: [],
+    template: WizardTemplate.fromJson(
+      jsonDecode(File('assets/wizard_template.json').readAsStringSync())
+          as Map<String, dynamic>,
+    ),
+    settings: BuildSettings(
+      tunApps: TunAppsConfig(mode: appsMode, packages: ['com.example']),
+      vpnMode: const VpnModeConfig.defaults().copyWith(mode: vpnMode),
+      routeFinal: 'direct-out',
+      customRules: [
+        CustomRuleInline(
+          name: 'Reject selected app',
+          packages: ['com.example'],
+          outbound: kOutboundReject,
+        ),
+      ],
+    ),
+  );
+
+  for (final vpnMode in ['vpn', 'vpn_proxy', 'proxy']) {
+    test(
+      'full builder ($vpnMode): direct after DNS, then switch back',
+      () async {
+        final direct = await build('direct', vpnMode);
+        expect(
+          direct.validation.isOk,
+          isTrue,
+          reason: direct.validation.issues.join('\n'),
+        );
+        final rules = (direct.config['route']['rules'] as List).cast<Map>();
+        final bypass = rules.where((r) => r['package_name'] != null).toList();
+        final tuns = (direct.config['inbounds'] as List).cast<Map>().where(
+          (i) => i['type'] == 'tun',
+        );
+        if (vpnMode == 'proxy') {
+          expect(tuns, isEmpty);
+          expect(bypass, isEmpty);
+        } else {
+          expect(tuns.single.containsKey('include_package'), isFalse);
+          expect(tuns.single.containsKey('exclude_package'), isFalse);
+          expect(bypass.single['outbound'], 'direct-out');
+          expect(bypass.single['inbound'], [tuns.single['tag']]);
+          final directIndex = rules.indexOf(bypass.single);
+          expect(
+            rules.indexWhere((r) => r['action'] == 'hijack-dns'),
+            allOf(greaterThanOrEqualTo(0), lessThan(directIndex)),
+          );
+          expect(
+            rules.indexWhere((r) => r['action'] == 'reject'),
+            greaterThan(directIndex),
+          );
+        }
+
+        for (final mode in ['off', 'deny']) {
+          final next = await build(mode, vpnMode);
+          expect(
+            next.validation.isOk,
+            isTrue,
+            reason: next.validation.issues.join('\n'),
+          );
+          expect(
+            (next.config['route']['rules'] as List).where(
+              (r) => (r as Map).containsKey('package_name'),
+            ),
+            isEmpty,
+          );
+          expect(next.config['dns'], direct.config['dns']);
+          if (vpnMode != 'proxy') {
+            final tun =
+                (next.config['inbounds'] as List).firstWhere(
+                      (i) => i['type'] == 'tun',
+                    )
+                    as Map;
+            expect(
+              tun['exclude_package'],
+              mode == 'deny' ? ['com.example'] : null,
+            );
+          }
+        }
+      },
+    );
+  }
+}

--- a/app/test/builder/tun_packages_test.dart
+++ b/app/test/builder/tun_packages_test.dart
@@ -130,6 +130,114 @@ void main() {
       expect(const TunAppsConfig(mode: 'off', packages: []).isOff, true);
       expect(const TunAppsConfig(mode: 'allow', packages: []).isAllow, true);
       expect(const TunAppsConfig(mode: 'deny', packages: []).isDeny, true);
+      expect(const TunAppsConfig(mode: 'direct', packages: []).isDirect, true);
+    });
+  });
+  group('Direct (lockdown)', () {
+    const selected = TunAppsConfig(mode: 'direct', packages: ['com.example']);
+
+    test('apps stay in the VPN; DNS precedes direct and routing follows', () {
+      final cfg = _configWithTun();
+      final tun = (cfg['inbounds'] as List).single as Map;
+      tun['include_package'] = ['com.other'];
+      tun['exclude_package'] = selected.packages;
+      final processing = [
+        {
+          'action': 'sniff',
+          'inbound': ['tun-in'],
+        },
+        {'action': 'hijack-dns', 'protocol': 'dns'},
+        {'action': 'resolve'},
+      ];
+      final routing = [
+        {'package_name': selected.packages, 'action': 'reject'},
+        {'outbound': 'vpn-1'},
+      ];
+      cfg['route'] = <String, dynamic>{
+        'rules': [...processing, ...routing],
+        'find_process': false,
+        'auto_detect_interface': false,
+        'final': 'vpn-1',
+      };
+      final dns = {
+        'rules': [
+          {'server': 'fakeip'},
+        ],
+        'final': 'dns-proxy',
+      };
+      cfg['dns'] = dns;
+
+      applyTunPackages(cfg, selected);
+
+      expect(tun.containsKey('include_package'), isFalse);
+      expect(tun.containsKey('exclude_package'), isFalse);
+      final route = cfg['route'] as Map;
+      final rules = route['rules'] as List;
+      expect(rules.take(processing.length), processing);
+      expect(rules[processing.length], {
+        'inbound': ['tun-in'],
+        'package_name': selected.packages,
+        'action': 'route',
+        'outbound': 'direct-out',
+      });
+      expect(rules.skip(processing.length + 1), routing);
+      expect(route['final'], 'vpn-1');
+      expect(route['find_process'], isTrue);
+      expect(route['auto_detect_interface'], isTrue);
+      expect(cfg['dns'], same(dns));
+    });
+
+    test('VPN+Proxy: direct is scoped to tun and leaves mixed-in alone', () {
+      final cfg = _configWithTun();
+      (cfg['inbounds'] as List).add({'type': 'mixed', 'tag': 'mixed-in'});
+      applyTunPackages(cfg, selected);
+      expect(cfg['route']['rules'].single['inbound'], ['tun-in']);
+      expect((cfg['inbounds'] as List).last, {
+        'type': 'mixed',
+        'tag': 'mixed-in',
+      });
+    });
+
+    test('Proxy without tun: no new routes', () {
+      final cfg = _configWithoutTun();
+      applyTunPackages(cfg, selected);
+      expect(cfg.containsKey('route'), isFalse);
+      expect((cfg['inbounds'] as List).single, {
+        'type': 'mixed',
+        'tag': 'mixed-in',
+      });
+    });
+
+    test('an empty list must not route every app directly', () {
+      final cfg = _configWithTun();
+      final tun = (cfg['inbounds'] as List).single as Map;
+      tun['exclude_package'] = ['com.example'];
+      applyTunPackages(cfg, const TunAppsConfig(mode: 'direct', packages: []));
+      expect(tun.containsKey('exclude_package'), isFalse);
+      expect(cfg.containsKey('route'), isFalse);
+    });
+
+    test('without initial DNS rules: direct precedes the first route', () {
+      final cfg = _configWithTun();
+      cfg['route'] = <String, dynamic>{
+        'rules': [
+          {'outbound': 'vpn-1'},
+        ],
+      };
+      applyTunPackages(cfg, selected);
+      expect(cfg['route']['rules'].first['package_name'], selected.packages);
+      expect(cfg['route']['rules'].last, {'outbound': 'vpn-1'});
+    });
+
+    test('an untagged tun gets a free tag to scope the rule', () {
+      final cfg = _configWithTun();
+      final inbounds = cfg['inbounds'] as List;
+      (inbounds.first as Map).remove('tag');
+      inbounds.add({'type': 'mixed', 'tag': 'tun-apps-in'});
+      applyTunPackages(cfg, selected);
+      final tag = inbounds.first['tag'];
+      expect(tag, isNot('tun-apps-in'));
+      expect(cfg['route']['rules'].single['inbound'], [tag]);
     });
   });
 }

--- a/app/test/screens/tun_apps_mode_test.dart
+++ b/app/test/screens/tun_apps_mode_test.dart
@@ -1,0 +1,83 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lxbox/controllers/home_controller.dart';
+import 'package:lxbox/controllers/subscription_controller.dart';
+import 'package:lxbox/screens/tun_apps_tab.dart';
+import 'package:lxbox/services/app_info_cache.dart';
+import 'package:lxbox/services/settings_storage.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const paths = MethodChannel('plugins.flutter.io/path_provider');
+  const native = MethodChannel('com.leadaxe.lxbox/methods');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+  late Directory tmp;
+
+  setUp(() async {
+    tmp = await Directory.systemTemp.createTemp('lxbox_tun_apps_ui_');
+    messenger.setMockMethodCallHandler(paths, (_) async => tmp.path);
+    messenger.setMockMethodCallHandler(native, (call) async {
+      if (call.method == 'getAppInfo') {
+        return {'packageName': 'com.example', 'appName': 'Example'};
+      }
+      return null;
+    });
+    SettingsStorage.resetCacheForTesting();
+    AppInfoCache.resetForTest();
+    await SettingsStorage.setTunApps(
+      const TunAppsConfig(mode: 'deny', packages: ['com.example']),
+      flush: false,
+    );
+  });
+
+  tearDown(() async {
+    SettingsStorage.resetCacheForTesting();
+    AppInfoCache.resetForTest();
+    messenger.setMockMethodCallHandler(paths, null);
+    messenger.setMockMethodCallHandler(native, null);
+    await tmp.delete(recursive: true);
+  });
+
+  testWidgets('selecting direct preserves apps and marks the config dirty', (
+    tester,
+  ) async {
+    final home = HomeController();
+    final subscriptions = SubscriptionController();
+    addTearDown(home.dispose);
+    addTearDown(subscriptions.dispose);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TunAppsTab(homeController: home, subController: subscriptions),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(DropdownButtonFormField<String>));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find
+          .byWidgetPredicate(
+            (w) => w is DropdownMenuItem<String> && w.value == 'direct',
+          )
+          .last,
+    );
+    await tester.pumpAndSettle();
+
+    expect((await SettingsStorage.getTunApps()).toJson(), {
+      'mode': 'direct',
+      'packages': ['com.example'],
+    });
+    expect(subscriptions.configDirty, isTrue);
+    expect(tester.takeException(), isNull);
+
+    await tester.pumpWidget(const SizedBox());
+    await tester.runAsync(() => SettingsStorage.flushToDisk());
+    await tester.pumpAndSettle();
+  });
+}

--- a/app/test/services/settings_storage_staging_test.dart
+++ b/app/test/services/settings_storage_staging_test.dart
@@ -112,6 +112,30 @@ void main() {
       expect(cfg.mode, 'allow');
       expect(cfg.packages, ['com.a']);
     });
+
+    test('deny → direct preserves packages, staging and mode after restart',
+        () async {
+      await SettingsStorage.setTunApps(
+        const TunAppsConfig(mode: 'deny', packages: ['com.b', 'com.a']),
+      );
+      final previous = await SettingsStorage.getTunApps();
+      await SettingsStorage.setTunApps(
+        previous.copyWith(mode: 'direct'),
+        flush: false,
+      );
+      final staged = await SettingsStorage.getTunApps();
+      expect(staged.isDirect, isTrue);
+      expect(staged.packages, previous.packages);
+      expect((await readDisk())['tun_apps']['mode'], 'deny');
+
+      await SettingsStorage.flushToDisk();
+      SettingsStorage.resetCacheForTesting();
+      final restored = await SettingsStorage.getTunApps();
+      expect(restored.toJson(), staged.toJson());
+
+      await SettingsStorage.setTunApps(restored.copyWith(mode: 'off'));
+      expect((await SettingsStorage.getTunApps()).packages, previous.packages);
+    });
   });
 
   group('§159 — DENY-очистка в _save() удалена', () {

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -779,11 +779,11 @@ part of this: they are an app setting, and their home in the portable format is 
 
 ## `tun_apps` — [§046]
 
-OS-level split tunneling: which applications go through the VPN tun and which go direct over cellular or Wi-Fi (bypassing sing-box entirely).
+App selection for OS-level split tunneling or direct routing through the core.
 
 ```jsonc
 {
-  "mode": "off" | "allow" | "deny",
+  "mode": "off" | "allow" | "deny" | "direct",
   "packages": ["com.example.app", "ru.tinkoff.investing", ...]
 }
 ```
@@ -793,6 +793,21 @@ OS-level split tunneling: which applications go through the VPN tun and which go
 | `"off"` | (nothing is written) | Every app goes through the tun (the Android default) |
 | `"allow"` | `"include_package": [...packages]` | Only the listed apps use the tun. The rest go direct |
 | `"deny"`  | `"exclude_package": [...packages]` | Everything EXCEPT the listed apps uses the tun |
+| `"direct"` | `include_package` / `exclude_package` removed | All apps enter tun; listed packages use `direct-out` inside the core |
+
+**Direct (lockdown):** adds a `package_name` → `direct-out` rule scoped to
+the tun inbound. It follows initial packet processing (`sniff`, `hijack-dns`,
+`resolve`, `route-options`) and precedes other routes. DNS, including FakeIP,
+continues to follow the existing DNS settings; this mode does not provide a
+separate direct DNS resolver. It enables `find_process` and
+`auto_detect_interface` for package lookup and native `protect()` calls on
+outgoing sockets. Without tun (Proxy mode), the setting has no effect.
+
+Apps stay inside the VPN and can connect with Android **Block connections
+without VPN** enabled while the VPN is running. When the VPN stops, lockdown
+blocks these apps too. Android/Shelter profile boundaries remain unchanged.
+The package list is shared across modes and preserved when switching modes.
+Restart the VPN after changing modes.
 
 **The native layer** (`BoxVpnService.kt`) reads `options.includePackage` / `excludePackage` from libbox and calls `VpnService.Builder.addAllowedApplication` / `addDisallowedApplication`.
 

--- a/docs/api/debug-api-reference.md
+++ b/docs/api/debug-api-reference.md
@@ -884,8 +884,8 @@ Scoped writes на `SettingsStorage`. Generic `PUT /state/storage?key=X` **на�
 | `/settings/ping_options/groups/{tag}` | GET | override этой группы или **404** если override нет. |
 | `/settings/ping_options/groups/{tag}` | PUT | body `{url?, timeout_ms?}` — минимум одно поле (read-modify-write). → `{ok, action:"settings-ping-options-group-put", group, ...}`. |
 | `/settings/ping_options/groups/{tag}` | DELETE | снять override группы. → `{ok, action:"settings-ping-options-group-delete", group}`. |
-| `/settings/tun_apps` | GET | →`{"mode":"off\|allow\|deny", "packages":[...]}` — §046 OS-level split-tunneling. |
-| `/settings/tun_apps` | PUT | `{"mode":"off\|allow\|deny", "packages":["pkg1","pkg2",...]}` — §046. Replace целиком. Дубликаты в `packages` schлопываются (idempotent). Пустые строки skip'аются. **§293:** `mode` вне `off\|allow\|deny` → 400 (валидатор `TunAppsConfig.isValidMode`); невалидный package-name → 400. Response: `{ok, action, mode, count, rebuild_needed: true, ...rebuild-extras}`. **Требует full VPN restart** для apply (Android tun creates только на `establish()`). |
+| `/settings/tun_apps` | GET | →`{"mode":"off\|allow\|deny\|direct", "packages":[...]}` — §046 per-app tunnel and direct routing settings. |
+| `/settings/tun_apps` | PUT | `{"mode":"off\|allow\|deny\|direct", "packages":["pkg1","pkg2",...]}` — replaces the whole object. Packages are deduplicated; empty strings are skipped. Invalid mode or package name → 400. `direct` keeps apps inside tun and routes selected packages through `direct-out` for Android lockdown. Response: `{ok, action, mode, count, rebuild_needed: true, ...rebuild-extras}`. **Restart the VPN** to apply OS tunnel changes. |
 | `/settings/vpn/allow_bypass` | GET | →`{"enabled": bool}` — §052/§049 F15. |
 | `/settings/vpn/allow_bypass` | PUT | `{"enabled": true\|false}` — §052/§049 F15. Native (`VpnService.Builder.allowBypass()`). Применяется при следующем `establish()` (start или reload VPN). Default false (strict tunnel). |
 | `/settings/vpn/keep_on_exit` | GET | →`{"enabled": bool}` — §052. VPN остаётся активным когда app закрывается. |


### PR DESCRIPTION
The change lets apps from the list work directly in VPN lockdown mode ('Block connections without VPN').
Requires the 'Unknown traffic' rule enabled separately to prevent tricks like `curl --interface tun1`.